### PR TITLE
Support contracts on non-generic functions on SBCL.

### DIFF
--- a/quid-pro-quo.asd
+++ b/quid-pro-quo.asd
@@ -20,12 +20,14 @@
                (:file "method-combination" :depends-on ("package"))
                (:file #+allegro "acl-fwrap"
                       #+ccl "ccl-advice"
-                      #-(or allegro ccl) "missing-advice"
+                      #+sbcl "sbcl-encapsulate"
+                      #-(or allegro ccl sbcl) "missing-advice"
                       :depends-on ("package"))
                (:file "macros" :depends-on ("method-combination"
                                             #+allegro "acl-fwrap"
                                             #+ccl "ccl-advice"
-                                            #-(or allegro ccl)
+                                            #+sbcl "sbcl-encapsulate"
+                                            #-(or allegro ccl sbcl)
                                             "missing-advice"))
                (:file "metaclass" :depends-on ("macros"))
                (:file "system-connections" :depends-on ("metaclass")
@@ -45,6 +47,6 @@
   :maintainer "Greg Pfeil <greg@technomadic.org>"
   :depends-on (quid-pro-quo fiveam)
   :components ((:file "quid-pro-quo-test")
-               (:file #+(or allegro ccl) "advice-tests"
-                      #-(or allegro ccl) "missing-advice-tests"
+               (:file #+(or allegro ccl sbcl) "advice-tests"
+                      #-(or allegro ccl sbcl) "missing-advice-tests"
                       :depends-on ("quid-pro-quo-test"))))

--- a/src/sbcl-encapsulate.lisp
+++ b/src/sbcl-encapsulate.lisp
@@ -1,0 +1,43 @@
+(in-package #:quid-pro-quo)
+
+(defmacro defcontract (name type lambda-list &body body)
+  "This macro makes it possible to add pre- and postconditions to non-generic
+   functions as well."
+  (multiple-value-bind (remaining-forms declarations doc-string)
+      (parse-body body :documentation t)
+    (let ((arglist (gensym "ARGLIST"))
+          (fdefn (gensym "FDEFN")))
+      `(progn
+         (sb-int:unencapsulate ',name ',(intern doc-string))
+         (sb-int:encapsulate
+          ',name ',(intern doc-string)
+          '(let ((,arglist (eval 'sb-int:arg-list))
+                 (,fdefn (eval 'sb-int:basic-definition)))
+            (destructuring-bind ,lambda-list ,arglist
+              ,@declarations
+              ,(ecase type
+                 (:require `(if (progn ,@remaining-forms)
+                                (apply ,fdefn ,arglist)
+                                (error 'precondition-error
+                                       :failed-check (fdefinition ',name)
+                                       :arguments ,arglist
+                                       :description ,doc-string)))
+                 (:guarantee (let ((%results (gensym "%RESULTS")))
+                               `(let ((,%results nil))
+                                  (flet ((results ()
+                                           (values-list ,%results)))
+                                    (ignore-errors
+                                     (let ((*preparing-postconditions* t)
+                                           (*inside-contract-p* t))
+                                       ,@remaining-forms))
+                                    (setf ,%results
+                                          (multiple-value-list
+                                           (apply ,fdefn ,arglist)))
+                                    (or (let ((*inside-contract-p* t))
+                                          ,@remaining-forms)
+                                        (error 'postcondition-error
+                                               :failed-check (fdefinition ',name)
+                                               :arguments ,arglist
+                                               :results (results)
+                                               :description ,doc-string))
+                                    (results)))))))))))))


### PR DESCRIPTION
Here I added support for function advising on SBCL.  I learned about this technique from a Leslie Polzer's post at http://blog.viridian-project.de/2008/05/04/function-encapsulation-in-sbcl/.

Error reporting is suboptimal as 2nd and further advices report obscure `#<CLOSURE sb-impl::encapsulation>` for the failed-check function.
